### PR TITLE
Enrich playlist tracker with notes and gear info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# playlist-notes-site
+# Playlist Notes Site
+
+This project is a simple static web page for keeping track of favorite playlists with notes, ratings, and tags. It also contains background information about the audio gear used in the system.
+
+## Equipment Overview
+
+### 1. Headphones / Earphones
+
+| Model | Background | Sound Signature |
+|-------|-----------|-----------------|
+| **STAX SR-L700 MK II** | Second-highest model in STAX's Lambda line. Replaceable 6N OFC + silver-plated flat cable. Technology derived from SR-009S. | Fast transients and silky treble. Neutral bass with clear layering. Pair with SRM-500T for warmth, ideal for indoor listening. |
+| **Sennheiser HD 820** | German closed-back flagship with concave Gorilla Glass acoustic chambers to reduce standing waves. 300 Ω impedance. | Expansive soundstage for a closed design, extremely low distortion and precise imaging. Best when driven fully balanced from HDV 820. |
+| **Meze 109 Pro** | Romanian handcrafted open-back dynamic. Wooden cups, 50 mm recessed diaphragm, 40 Ω impedance. | Full-bodied mids and lows, comfortable for long sessions. With the RU9 it gains thickness and a larger stage. |
+| **Sennheiser IE 900** | Single 7 mm XWB dynamic IEM with aluminum CNC housing and triple-chamber damping. | Razor-like resolution and clean background. Excellent treble extension without harshness. Works well with RU9 in Modern Tube mode for smoother vocals. |
+| **Sony IER-Z1R** | Triple dynamic hybrid flagship IEM (14 mm + 12 mm + 5 mm). Beryllium-coated bass, magnesium mid, acoustic tubes for "stage" presentation. | Strong bass presence and impact, transparent mids/highs with wide space. Pairs best with ZX707 for full Sony synergy. |
+
+### 2. Amplifiers & Desktop DACs
+
+| Model | Background | Highlights |
+|-------|-----------|-----------|
+| **STAX SRM-500T** | Hybrid FET + 6FQ7/6CG7 tube amplifier, 300 V RMS output. Bias 580 V DC. | Tube warmth softens typical electrostatic coldness. Compact stack for desks. |
+| **Sennheiser HDV 820** | Dual AKM4490EQ DAC, supports PCM 32‑bit/384 kHz and DSD256. | Fully balanced amplification with 2 W @ 32 Ω. Matches HD 820's design. Can act as a preamp for powered speakers. |
+| **iFi Zen DAC V3** | USB‑C powered, Burr‑Brown DAC, supports DSD256 and DXD 384 kHz. | X‑Bass and X‑Space toggles. PowerMatch gain for IEMs. Budget-friendly for office use. |
+
+### 3. Portable Sources & DACs
+
+| Model | Background | Highlights |
+|-------|-----------|-----------|
+| **Sony NW-ZX707** | Android 12 Walkman with S‑Master HX digital amp. 64 GB storage + microSD. USB DAC up to 32‑bit/384 kHz, DSD 11.2 MHz. | DSEE Ultimate upscaling and Vinyl Processor. Smooth performance with QCS4290. Up to 25 hr battery for long trips. |
+| **Cayin RU9** | Dual AK4493SEQ DAC + Nutube 6P1. Three tone modes (Classic Tube, Modern Tube, Solid State). 730 mW @ 32 Ω from 4.4 mm. USB‑C and Bluetooth 5.1. | With iPhone: 1) USB via Lightning camera adapter for up to 768 kHz/DSD512. 2) Bluetooth LDAC up to 96 kHz for convenience. Magnetic back plate sticks firmly to phone. Tube modes add harmonic richness, Solid State retains clarity. |
+
+## Usage Tips
+
+- **RU9 Switching**
+  - Use Solid State mode for reference listening via USB, then try the tube modes for comparison.
+  - Over Bluetooth choose LDAC 990 kbps. iPhone users need the *Cayin Audio* app for filter and tube mode options.
+- **Cable Advice**
+  - Use 4.4 mm balanced cables on 109 Pro, IE 900, and IER-Z1R so they work with the RU9, HDV 820, and ZX707.
+  - STAX uses a dedicated 5‑pin cable; do not mix with dynamic headphone cables.
+- **Quick Pairings**
+  - Late night indoor → SR-L700 MK II with SRM-500T for ultra-low noise.
+  - Office work → Meze 109 Pro with Zen DAC V3, enable X‑Space for a wider stage.
+  - Commute → IE 900 with RU9 over Bluetooth.
+  - Live rock → IER-Z1R with ZX707 on 4.4 mm.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,35 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+  line-height: 1.6;
+}
+
+h1 {
+  margin-bottom: 1rem;
+}
+
+#playlist-form input,
+#playlist-form textarea {
+  display: block;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+.playlist-item {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 5px;
+}
+
+.tag {
+  background: #eee;
+  padding: 0 0.5rem;
+  border-radius: 3px;
+  margin-right: 0.25rem;
+  display: inline-block;
+}
+
+.rating {
+  color: #e0a800;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,54 @@
+const container = document.getElementById('playlist-container');
+const form = document.getElementById('playlist-form');
+const nameInput = document.getElementById('name');
+const noteInput = document.getElementById('notes');
+const tagInput = document.getElementById('tags');
+const ratingInput = document.getElementById('rating');
+
+function savePlaylists(list) {
+  localStorage.setItem('playlists', JSON.stringify(list));
+}
+
+function loadPlaylists() {
+  const stored = localStorage.getItem('playlists');
+  return stored ? JSON.parse(stored) : [];
+}
+
+function render() {
+  container.innerHTML = '';
+  playlists.forEach((p, index) => {
+    const div = document.createElement('div');
+    div.className = 'playlist-item';
+    div.innerHTML = `
+      <strong>${p.name}</strong>
+      <span class="rating">${'★'.repeat(p.rating)}</span>
+      <div>${p.notes}</div>
+      <div>${p.tags.map(t => `<span class="tag">${t}</span>`).join('')}</div>
+      <button data-index="${index}">Delete</button>
+    `;
+    div.querySelector('button').addEventListener('click', e => {
+      const i = parseInt(e.target.dataset.index, 10);
+      playlists.splice(i, 1);
+      savePlaylists(playlists);
+      render();
+    });
+    container.appendChild(div);
+  });
+}
+
+const playlists = loadPlaylists();
+render();
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const tags = tagInput.value.split(',').map(t => t.trim()).filter(Boolean);
+  playlists.push({
+    name: nameInput.value,
+    notes: noteInput.value,
+    rating: parseInt(ratingInput.value, 10) || 0,
+    tags
+  });
+  savePlaylists(playlists);
+  form.reset();
+  render();
+});

--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
 </head>
 <body>
   <h1>🎧 我的歌單筆記</h1>
+  <form id="playlist-form">
+    <input id="name" placeholder="歌單名稱" required>
+    <input id="rating" type="number" min="1" max="5" placeholder="1-5 分">
+    <input id="tags" placeholder="標籤，以逗號分隔">
+    <textarea id="notes" placeholder="聆聽建議或心得"></textarea>
+    <button type="submit">新增</button>
+  </form>
   <div id="playlist-container"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add equipment descriptions to README
- build playlist form with rating and tags
- add styling and localStorage JS logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687332a721008332ac8420f73d3bdbe4